### PR TITLE
Correct return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ const flatten = <T>(arr: T[][]): T[] => {
  * @param {LookPathOption} opt Options for lookpath.
  * @return {Promise<string>} Resolves absolute file path, or undefined if not found.
  */
-export async function lookpath(command: string, opt: LookPathOption = {path: []}): Promise<string> {
+export async function lookpath(command: string, opt: LookPathOption = {path: []}): Promise<string | undefined> {
 
     const directpath = isFilepath(command);
     if (directpath) return isExecutable(directpath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ const flatten = <T>(arr: T[][]): T[] => {
  * and resolves with undefined if the command not found.
  * @param {string} command Command name to look for.
  * @param {LookPathOption} opt Options for lookpath.
- * @return {Promise<string>} Resolves absolute file path, or undefined if not found.
+ * @return {Promise<string|undefined>} Resolves absolute file path, or undefined if not found.
  */
 export async function lookpath(command: string, opt: LookPathOption = {path: []}): Promise<string | undefined> {
 


### PR DESCRIPTION
README.md promises to return `undefined` if command is not found, TypeScript types should reflect that.