### PR TITLE
Fixes engine check

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.5",
   "description": "The minimum and most straightforward way to check if command exists and where the executable is.",
   "engines": {
-    "npm": "=>6.13.4"
+    "npm": ">=6.13.4"
   },
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
It should be >= not =>

 => fails

```
npm i lookpath --save-dev --save-exact                                                                                                                                       [±PD-491-soft-delete-lists ●● a0b3e0dc9 Fix partner gate use]
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for lookpath@1.0.5: wanted: {"npm":"=>6.13.4"} (current: {"node":"12.16.2","npm":"6.14.4"})
npm ERR! notsup Not compatible with your version of node/npm: lookpath@1.0.5
npm ERR! notsup Not compatible with your version of node/npm: lookpath@1.0.5
npm ERR! notsup Required: {"npm":"=>6.13.4"}
npm ERR! notsup Actual:   {"npm":"6.14.4","node":"12.16.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/luis/.npm/_logs/2020-04-23T05_05_43_888Z-debug.log

```